### PR TITLE
BUGFIX/MINOR(users): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
     state: present
   with_items: "{{ openio_users_group }}"
   when: openio_users_group is defined and openio_users_group
+  tags: install
 
 - name: Adding secondary groups
   group:
@@ -15,6 +16,7 @@
     state: present
   with_items: "{{ openio_users_groups | default([]) }}"
   when: openio_users_groups is defined and openio_users_groups
+  tags: install
 
 - name: Adding users
   user:
@@ -35,6 +37,7 @@
     shell: "{{ item.shell | default(omit) }}"
     update_password: "{{ item.update_password | default(omit) }}"
   with_items: "{{ openio_users_add }}"
+  tags: install
 
 - name: Setting user's home permission
   file:
@@ -46,6 +49,7 @@
   when: item.home_create is not defined or item.home_create
   with_items: "{{ openio_users_add }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: install
 
 - name: Adding user's .ssh directory
   file:
@@ -57,6 +61,7 @@
     mode: '0700'
   when: item.home_create is not defined or item.home_create
   with_items: "{{ openio_users_add }}"
+  tags: install
 
 - name: Adding user's private key
   template:
@@ -69,6 +74,7 @@
     mode: '0600'
   when: (item.home_create is not defined or item.home_create) and item.ssh_key is defined
   with_items: "{{ openio_users_add }}"
+  tags: install
 
 - name: Adding user's authorized keys
   authorized_key:
@@ -78,6 +84,7 @@
   when: item.home_create is not defined or item.home_create
   with_items: "{{ openio_users_add }}"
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: install
 
 - name: Removing users
   user:
@@ -85,4 +92,5 @@
     state: absent
     remove: true
   with_items: "{{ openio_users_remove }}"
+  tags: install
 ...


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION